### PR TITLE
Bugfix/core 458 set dist tag

### DIFF
--- a/build-publish/action.yml
+++ b/build-publish/action.yml
@@ -6,6 +6,10 @@ inputs:
     description: Output folder of build
     required: false
     default: ./dist
+  dist_tag:
+    description: Tag for the npm package
+    required: false
+    default: latest
   node_auth_token:
     description: Node auth token environment variable
     required: true
@@ -58,6 +62,6 @@ runs:
       shell: bash
       run: |
         echo "[>>>] npm publish"
-        npm publish ${{ inputs.dist_folder }}
+        npm publish ${{ inputs.dist_folder }} --tag ${{ inputs.dist_tag }}
       env:
         NODE_AUTH_TOKEN: ${{ inputs.node_auth_token }}

--- a/build-publish/action.yml
+++ b/build-publish/action.yml
@@ -6,10 +6,10 @@ inputs:
     description: Output folder of build
     required: false
     default: ./dist
-  dist_tag:
-    description: Tag for the npm package
+  main_branch:
+    description: Name of branch that latest release comes from
     required: false
-    default: latest
+    default: main
   node_auth_token:
     description: Node auth token environment variable
     required: true
@@ -58,10 +58,20 @@ runs:
         echo "[>>>] npm version ${{ inputs.package_version }}"
         npm version ${{ inputs.package_version }} -no-git-tag-version
 
-    - name: Publish
+    - name: Publish Latest
+      if: github.ref == 'refs/heads/${{ inputs.main_branch }}' 
       shell: bash
       run: |
         echo "[>>>] npm publish"
-        npm publish ${{ inputs.dist_folder }} --tag ${{ inputs.dist_tag }}
+        npm publish ${{ inputs.dist_folder }} --tag latest
+      env:
+        NODE_AUTH_TOKEN: ${{ inputs.node_auth_token }}
+
+    - name: Publish Experimental
+      if: github.ref != 'refs/heads/${{ inputs.main_branch }}' 
+      shell: bash
+      run: |
+        echo "[>>>] npm publish"
+        npm publish ${{ inputs.dist_folder }} --tag experimental
       env:
         NODE_AUTH_TOKEN: ${{ inputs.node_auth_token }}

--- a/build-publish/action.yml
+++ b/build-publish/action.yml
@@ -61,7 +61,7 @@ runs:
     - name: Publish
       shell: bash
       run: |
-        DIST_TAG=$([ ${{ github.ref }} = 'refs/heads/${{ inputs.main_branch }}' ] && echo 'latest' || echo 'experimental')
+        DIST_TAG=$([ ${{ github.ref }} != 'refs/heads/${{ inputs.main_branch }}' ] && echo 'latest' || echo 'experimental')
         echo "[>>>] npm publish $DIST_TAG ${{ github.ref }}"
         npm publish ${{ inputs.dist_folder }} --tag $DIST_TAG
       env:

--- a/build-publish/action.yml
+++ b/build-publish/action.yml
@@ -61,8 +61,8 @@ runs:
     - name: Publish
       shell: bash
       run: |
-        DIST_TAG=$([ ${{ github.ref }} != 'refs/heads/${{ inputs.main_branch }}' ] && echo 'latest' || echo 'experimental')
-        echo "[>>>] npm publish $DIST_TAG ${{ github.ref }}"
+        DIST_TAG=$([ ${{ github.ref }} = 'refs/heads/${{ inputs.main_branch }}' ] && echo 'latest' || echo 'experimental')
+        echo "[>>>] npm publish $DIST_TAG"
         npm publish ${{ inputs.dist_folder }} --tag $DIST_TAG
       env:
         NODE_AUTH_TOKEN: ${{ inputs.node_auth_token }}

--- a/build-publish/action.yml
+++ b/build-publish/action.yml
@@ -58,20 +58,11 @@ runs:
         echo "[>>>] npm version ${{ inputs.package_version }}"
         npm version ${{ inputs.package_version }} -no-git-tag-version
 
-    - name: Publish Latest
-      if: github.ref == 'refs/heads/${{ inputs.main_branch }}' 
+    - name: Publish
       shell: bash
       run: |
-        echo "[>>>] npm publish"
-        npm publish ${{ inputs.dist_folder }} --tag latest
-      env:
-        NODE_AUTH_TOKEN: ${{ inputs.node_auth_token }}
-
-    - name: Publish Experimental
-      if: github.ref != 'refs/heads/${{ inputs.main_branch }}' 
-      shell: bash
-      run: |
-        echo "[>>>] npm publish"
-        npm publish ${{ inputs.dist_folder }} --tag experimental
+        DIST_TAG=$([ ${{ github.ref }} = 'refs/heads/${{ inputs.main_branch }}' ] && echo 'latest' || echo 'experimental')
+        echo "[>>>] npm publish $DIST_TAG"
+        npm publish ${{ inputs.dist_folder }} --tag $DIST_TAG
       env:
         NODE_AUTH_TOKEN: ${{ inputs.node_auth_token }}

--- a/build-publish/action.yml
+++ b/build-publish/action.yml
@@ -62,7 +62,7 @@ runs:
       shell: bash
       run: |
         DIST_TAG=$([ ${{ github.ref }} = 'refs/heads/${{ inputs.main_branch }}' ] && echo 'latest' || echo 'experimental')
-        echo "[>>>] npm publish $DIST_TAG"
+        echo "[>>>] npm publish $DIST_TAG ${{ github.ref }}"
         npm publish ${{ inputs.dist_folder }} --tag $DIST_TAG
       env:
         NODE_AUTH_TOKEN: ${{ inputs.node_auth_token }}

--- a/build-publish/action.yml
+++ b/build-publish/action.yml
@@ -6,8 +6,8 @@ inputs:
     description: Output folder of build
     required: false
     default: ./dist
-  is_release_branch:
-    description: Is branch that latest release comes from
+  is_release:
+    description: True if package is latest release
     required: false
     default: 'true'
   node_auth_token:
@@ -61,7 +61,7 @@ runs:
     - name: Publish
       shell: bash
       run: |
-        DIST_TAG=$([ ${{ inputs.is_release_branch }} = 'true' ] && echo 'latest' || echo 'experimental')
+        DIST_TAG=$([ ${{ inputs.is_release }} = 'true' ] && echo 'latest' || echo 'experimental')
         echo "[>>>] npm publish $DIST_TAG"
         npm publish ${{ inputs.dist_folder }} --tag $DIST_TAG
       env:

--- a/build-publish/action.yml
+++ b/build-publish/action.yml
@@ -6,10 +6,10 @@ inputs:
     description: Output folder of build
     required: false
     default: ./dist
-  main_branch:
-    description: Name of branch that latest release comes from
+  is_release_branch:
+    description: Is branch that latest release comes from
     required: false
-    default: main
+    default: 'true'
   node_auth_token:
     description: Node auth token environment variable
     required: true
@@ -61,7 +61,7 @@ runs:
     - name: Publish
       shell: bash
       run: |
-        DIST_TAG=$([ ${{ github.ref }} = 'refs/heads/${{ inputs.main_branch }}' ] && echo 'latest' || echo 'experimental')
+        DIST_TAG=$([ ${{ inputs.is_release_branch }} = 'true' ] && echo 'latest' || echo 'experimental')
         echo "[>>>] npm publish $DIST_TAG"
         npm publish ${{ inputs.dist_folder }} --tag $DIST_TAG
       env:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "core-github-actions",
+  "version": "1",
+  "lockfileVersion": 1
+}


### PR DESCRIPTION
## Dependencies of PR

<!-- Please list any dependencies this pull request has -->

## Description of Changes

<!-- Please describe the changes you made -->
- Add `is_release` input that should be set to false if you want your npm package to get tagged as `experimental` to ensure beta packages dont get set to `latest`
## Testing

<!-- Please describe any testing you ran manually -->
- tested setting `is_release` to true and also false in the user auth library repo and verified the releases were tagged appropriately
[Jira Task Link](https://opensesame.atlassian.net/browse/)
