### PR TITLE
Bugfix/core 658 build apply optional output

### DIFF
--- a/build-apply/action.yml
+++ b/build-apply/action.yml
@@ -93,4 +93,8 @@ runs:
         echo "[>>>] transform terraform outputs to environment variables"
         terraform output -json | jq 'to_entries | map("TF_\(.key|ascii_upcase)=\(.value.value|tostring)") | .[]' -r >> $GITHUB_ENV
 
-        echo "::set-output name=name_prefix::$(terraform output name_prefix)"
+        if terraform output name_prefix; then
+          echo "::set-output name=name_prefix::$(terraform output name_prefix)"
+        else
+          echo ""
+        fi

--- a/build-apply/action.yml
+++ b/build-apply/action.yml
@@ -96,5 +96,5 @@ runs:
         if terraform output name_prefix; then
           echo "::set-output name=name_prefix::$(terraform output name_prefix)"
         else
-          echo ""
+          echo "name_prefix output not set. If you were expecting a name_prefix to be set, please fix this issue."
         fi

--- a/deploy/action.yml
+++ b/deploy/action.yml
@@ -14,11 +14,6 @@ inputs:
     description: "Node auth token environment variable"
     required: false
 
-outputs:
-  name_prefix:
-    description: "The computed name_prefix"
-    value: ${{ steps.set_outputs.outputs.name_prefix }}
-
 runs:
   using: "composite"
   steps:


### PR DESCRIPTION
## Dependencies of PR

None.

## Description of Changes

Changes the final step in the build-apply action to provide more useful messages if/when using the name_prefix output fails.

Also removes the output code from the deploy action since this was previously moved to the build-apply action.

## Testing

Tested the changes against a repo _without_ a name_prefix output (identity-client-reference-app) and made sure build was still functional.
Test the changes against a repo _with_ a name_prefix output (identity-idp-api) and made sure build was still functional.

[Jira Task Link](https://opensesame.atlassian.net/browse/CORE-658)
