### PR TITLE
terraform 0.14+ requires output to have raw flag to not include quotes

### DIFF
--- a/build-apply/action.yml
+++ b/build-apply/action.yml
@@ -94,7 +94,7 @@ runs:
         terraform output -json | jq 'to_entries | map("TF_\(.key|ascii_upcase)=\(.value.value|tostring)") | .[]' -r >> $GITHUB_ENV
 
         if terraform output name_prefix; then
-          echo "::set-output name=name_prefix::$(terraform output name_prefix)"
+          echo "::set-output name=name_prefix::$(terraform output -raw name_prefix)"
         else
           echo "name_prefix output not set. If you were expecting a name_prefix to be set, please fix this issue."
         fi


### PR DESCRIPTION
## Dependencies of PR

<!-- Please list any dependencies this pull request has -->

## Description of Changes
- TF 0.14 and up changed the way `terraform output` returned it's vars. We now need to pass the `-raw` flag to get the output without quotes

<!-- Please describe the changes you made -->

## Testing

<!-- Please describe any testing you ran manually -->

[Jira Task Link](https://opensesame.atlassian.net/browse/)
