### PR TITLE
remove TF upgrade flag so we respect lock files

### DIFF
--- a/build-apply/action.yml
+++ b/build-apply/action.yml
@@ -74,7 +74,7 @@ runs:
       working-directory: terraform/${{ inputs.terraform_root }}
       run: |
         echo "[>>>] terraform init"
-        terraform init -upgrade
+        terraform init
 
         echo "[>>>] select terraform workspace ${{ inputs.terraform_workspace }}"
         node ../../node_modules/.bin/core-build select-workspace -w ${{ inputs.terraform_workspace }}

--- a/cleanup/action.yml
+++ b/cleanup/action.yml
@@ -53,7 +53,7 @@ runs:
       working-directory: terraform/${{ inputs.terraform_root }}
       run: |
         echo "[>>>] terraform init"
-        terraform init -upgrade
+        terraform init
 
         echo "[>>>] select terraform workspace ${{ inputs.terraform_workspace }}"
         node ../../node_modules/.bin/core-build select-workspace -w ${{ inputs.terraform_workspace }}

--- a/deploy/action.yml
+++ b/deploy/action.yml
@@ -37,7 +37,7 @@ runs:
       working-directory: terraform/${{ inputs.terraform_root }}
       run: |
         echo terraform init
-        terraform init -upgrade
+        terraform init
 
         echo select terraform workspace ${{ inputs.terraform_workspace }}
         node ../../node_modules/.bin/core-build select-workspace -w ${{ inputs.terraform_workspace }}


### PR DESCRIPTION
## Dependencies of PR

<!-- Please list any dependencies this pull request has -->

## Description of Changes
- Remove `-upgrade` flag from when we call `terraform init`, so we respect the TF lock file in a repo
<!-- Please describe the changes you made -->

## Testing

<!-- Please describe any testing you ran manually -->

[Jira Task Link](https://opensesame.atlassian.net/browse/)
