### PR TITLE
Add github build workflow

### DIFF
--- a/build/action.yml
+++ b/build/action.yml
@@ -2,7 +2,7 @@ name: Build
 description: Build Project
 inputs:
   github_ssh_key:
-    description: Github SSH Key to read shared terraform modules
+    description: Github SSH Key to read private GitHub packages
     required: true
   node_auth_token:
     description: Node auth token environment variable
@@ -39,9 +39,3 @@ runs:
       run: |
         echo "[>>>] npm run build --if-present"
         npm run build --if-present
-
-    - name: Read Secrets Into Env
-      shell: bash
-      run: |
-        echo "[>>>] read secrets into ./terraform/.env"
-        ./node_modules/.bin/core-build build-secrets > ./terraform/.env


### PR DESCRIPTION
## Description of Changes
- Turns out that five of our repos were failing to build and required the github credentials in the workflow. 
- This PR add github credentials to build action workflow 

## Testing
- Tested locally on the failing repos and got them to pass.

[Jira Task Link](https://opensesame.atlassian.net/browse/)
