### PR TITLE
Feature: Compact hook

### DIFF
--- a/build-apply/action.yml
+++ b/build-apply/action.yml
@@ -69,6 +69,12 @@ runs:
         echo "[>>>] read secrets into ./terraform/.env"
         ./node_modules/.bin/core-build build-secrets > ./terraform/.env
 
+    - name: Remove NodeJs devDependencies
+      shell: bash
+      run: |
+        echo "[>>>] npm run compact --if-present"
+        npm run compact --if-present
+
     - name: Install Python Dependencies
       shell: bash
       working-directory: terraform

--- a/build-publish/action.yml
+++ b/build-publish/action.yml
@@ -58,6 +58,12 @@ runs:
         echo "[>>>] npm version ${{ inputs.package_version }}"
         npm version ${{ inputs.package_version }} -no-git-tag-version
 
+    - name: Remove NodeJs devDependencies
+      shell: bash
+      run: |
+        echo "[>>>] npm run compact --if-present"
+        npm run compact --if-present
+
     - name: Publish
       shell: bash
       run: |

--- a/build/action.yml
+++ b/build/action.yml
@@ -39,3 +39,9 @@ runs:
       run: |
         echo "[>>>] npm run build --if-present"
         npm run build --if-present
+
+    - name: Remove NodeJs devDependencies
+      shell: bash
+      run: |
+        echo "[>>>] npm run compact --if-present"
+        npm run compact --if-present

--- a/cleanup/action.yml
+++ b/cleanup/action.yml
@@ -54,6 +54,12 @@ runs:
         echo "[>>>] read secrets into ./terraform/.env"
         ./node_modules/.bin/core-build build-secrets > ./terraform/.env
 
+    - name: Remove NodeJs devDependencies
+      shell: bash
+      run: |
+        echo "[>>>] npm run compact --if-present"
+        npm run compact --if-present
+
     - name: Terraform Cleanup
       shell: bash
       working-directory: terraform/${{ inputs.terraform_root }}


### PR DESCRIPTION
Adding an optional NPM lifecycle hook which users can define to… handle any post-build cleanup

## Description of Changes

If your project defines a hook (ie something in the `scripts` block) in your project's root `package.json` named `compact`, the build actions will invoke it _after_ the `build` hook has been called and _before_ deploying the application code. This can be useful if you need to ensure all the dependencies used to build the app are _not_ part of the zipped up archive deployed to AWS.

Chaining (locally) onto the normal `build` hook isn't an ideal thing to do, because it makes it really expensive to invoke `npm run build` locally. Shaving off dev dependencies should be something done in a pipeline, rather than something which takes place routinely during local development.

Thoughts on whether "compact" is the best name for this? Open to other alias suggestions.

## Testing

Define the `compact` hook in your root `package.json` and then ensure it shows up in the github action output as having been invoked.