### PR TITLE
CORE-1730 Fix Terraform init upgrade for build and apply

### DIFF
--- a/build-apply/action.yml
+++ b/build-apply/action.yml
@@ -89,7 +89,7 @@ runs:
       working-directory: terraform/${{ inputs.terraform_root }}
       run: |
         echo "[>>>] terraform init"
-        terraform init
+        terraform init -upgrade
 
         echo "[>>>] select terraform workspace ${{ inputs.terraform_workspace }}"
         node ../../node_modules/.bin/core-build select-workspace -w ${{ inputs.terraform_workspace }}


### PR DESCRIPTION
## Dependencies of PR
None

## Description of Changes
On the actions build-apply it was executing terraform init instead of terraform init -upgrade, the difference remains in the fact that terraform upgrade updates the terraform.hcl.lock files

## Testing
Delete .terraform and terraform.hcl.lock files locally,
Cli: Terraform init -updagrade.
Result: the files were recreated.
Aditional review: Terraform plan to stage and prod execute terraform init -upgrade 

[Jira Task Link CORE-1730 ](https://opensesame.atlassian.net/browse/CORE-1730)
