### PR TITLE
Feature/CORE-1921

### DIFF
--- a/build-apply/action.yml
+++ b/build-apply/action.yml
@@ -13,6 +13,10 @@ inputs:
   node_auth_token:
     description: Node auth token environment variable
     required: false
+  skip_test:
+    description: Skip unit test and handle by its own
+    default: 'no'
+    required: false
 
 outputs:
   name_prefix:
@@ -59,6 +63,7 @@ runs:
 
     - name: Test
       shell: bash
+      if: ${{ inputs.skip_test == 'no' }}
       run: |
         echo "[>>>] npm run test --if-present"
         npm run test --if-present


### PR DESCRIPTION
## Description of Changes

Add the possibility of skipping unit tests --if-present if they are run by the repository workflow itself (environment targeting different selection), like the Identity User Management API. Default set to not skip, if the user wants to skip must set skip_test equals to 'skip' literal.

## Testing

[Jira Task Link](https://opensesame.atlassian.net/browse/)
