### PR TITLE
CORE-2191 Add token to build step

### DIFF
--- a/build-apply/action.yml
+++ b/build-apply/action.yml
@@ -60,6 +60,8 @@ runs:
       run: |
         echo "[>>>] npm run build --if-present"
         npm run build --if-present
+      env:
+        NODE_AUTH_TOKEN: ${{ inputs.node_auth_token }}
 
     - name: Test
       shell: bash


### PR DESCRIPTION
The step Npm CI includes npm install. This step includes a secret node_auth_token. This token has the rights to download open sesame packages.

Prior to this PR the Build step did not also have the node_auth_token. package.json for our api projects however also runs npm install as part of the post-build script. If the dependencies include an opensesame package, without the node_auth_token, npm install fails with 401.

We never noticed this until now because we don't really write runtime libraries. I could probably find a local way around this problem consuming the identity-messages package, but this is a bug preventing creating runtime libraries of our own, so I am fixing it here.