### PR TITLE
Feature/CORE-3303

### DIFF
--- a/tf-plan-comment/action.yml
+++ b/tf-plan-comment/action.yml
@@ -1,8 +1,8 @@
 name: Terraform Plan Comment
 description: Create a terraform plan comment in the PR
 inputs:
-  terraform_plan:
-    description: The contents of the terraform plan
+  terraform_plan_path:
+    description: The path to the file containing the contents of the terraform plan
     required: true
   terraform_environment:
     description: Terraform environment
@@ -11,10 +11,20 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Download Terraform Plan Artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: terraform-plan
+        path: /tmp/terraform-plan
+
+    - name: Read Terraform Plan
+      id: read_plan
+      run: echo "TERRAFORM_PLAN=$(cat /tmp/terraform-plan/${{ inputs.terraform_plan_path }})" >> $GITHUB_ENV
+
     - name: Comment on PR
       uses: actions/github-script@v6
       env:
-        PLAN: "${{ inputs.terraform_plan }}"
+        PLAN: ${{ env.TERRAFORM_PLAN }}
       with:
         script: |
           const CODE_BLOCK = '```';

--- a/tf-plan-comment/action.yml
+++ b/tf-plan-comment/action.yml
@@ -1,7 +1,7 @@
 name: Terraform Plan Comment
 description: Create a terraform plan comment in the PR
 inputs:
-  terraform_plan_path:
+  terraform_plan_file:
     description: The path to the file containing the contents of the terraform plan
     required: true
   terraform_environment:
@@ -11,19 +11,16 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Download Terraform Plan Artifact
-      uses: actions/download-artifact@v2
-      with:
-        name: terraform-plan
-        path: /tmp/terraform-plan
-
     - name: Read Terraform Plan
-      id: read_plan
-      run: echo "TERRAFORM_PLAN=$(cat /tmp/terraform-plan/${{ inputs.terraform_plan_path }})" >> $GITHUB_ENV
       shell: bash
+      run: |
+        PLAN_CONTENTS=$(cat ${{ inputs.terraform_plan_file }})
+        echo "TERRAFORM_PLAN=$PLAN_CONTENTS" >> $GITHUB_ENV
 
     - name: Comment on PR
       uses: actions/github-script@v6
+      env:
+        PLAN: ${{ env.TERRAFORM_PLAN }}
       with:
         script: |
           const CODE_BLOCK = '```';
@@ -33,9 +30,9 @@ runs:
           <details>
           <summary>Logs</summary>
 
-          ${ CODE_BLOCK }terraform
-          ${ process.env.PLAN }
-          ${ CODE_BLOCK }
+          ${CODE_BLOCK}terraform
+          ${process.env.PLAN}
+          ${CODE_BLOCK}
           </details>
 
           *Pusher: @${{ github.actor }}, Action: \`${{ github.event_name }}\`, Workflow: \`${{ github.workflow }}\`*
@@ -47,5 +44,3 @@ runs:
             repo: context.repo.repo,
             body: output
           });
-      env:
-        PLAN: ${{ env.TERRAFORM_PLAN }}

--- a/tf-plan-comment/action.yml
+++ b/tf-plan-comment/action.yml
@@ -19,14 +19,11 @@ runs:
 
     - name: Read Terraform Plan
       id: read_plan
-      shell: bash
       run: echo "TERRAFORM_PLAN=$(cat /tmp/terraform-plan/${{ inputs.terraform_plan_path }})" >> $GITHUB_ENV
+      shell: bash
 
     - name: Comment on PR
       uses: actions/github-script@v6
-      shell: bash
-      env:
-        PLAN: ${{ env.TERRAFORM_PLAN }}
       with:
         script: |
           const CODE_BLOCK = '```';
@@ -50,3 +47,5 @@ runs:
             repo: context.repo.repo,
             body: output
           });
+      env:
+        PLAN: ${{ env.TERRAFORM_PLAN }}

--- a/tf-plan-comment/action.yml
+++ b/tf-plan-comment/action.yml
@@ -11,27 +11,22 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Read Terraform Plan
-      shell: bash
-      run: |
-        PLAN_CONTENTS=$(cat ${{ inputs.terraform_plan_file }})
-        echo "TERRAFORM_PLAN=$PLAN_CONTENTS" >> $GITHUB_ENV
-
     - name: Comment on PR
       uses: actions/github-script@v6
-      env:
-        PLAN: ${{ env.TERRAFORM_PLAN }}
       with:
         script: |
+          const fs = require('fs');
           const CODE_BLOCK = '```';
+          const planPath = '${{ inputs.terraform_plan_file }}';
+          const planContents = fs.readFileSync(planPath, 'utf8');
 
           const output = `
-          ### Terraform Plan ${{ inputs.terraform_environment }} 🔍
+          ### Terraform Plan for ${{ inputs.terraform_environment }} 🔍
           <details>
-          <summary>Logs</summary>
+          <summary>Click to view plan details</summary>
 
           ${CODE_BLOCK}terraform
-          ${process.env.PLAN}
+          ${planContents}
           ${CODE_BLOCK}
           </details>
 

--- a/tf-plan-comment/action.yml
+++ b/tf-plan-comment/action.yml
@@ -19,10 +19,12 @@ runs:
 
     - name: Read Terraform Plan
       id: read_plan
+      shell: bash
       run: echo "TERRAFORM_PLAN=$(cat /tmp/terraform-plan/${{ inputs.terraform_plan_path }})" >> $GITHUB_ENV
 
     - name: Comment on PR
       uses: actions/github-script@v6
+      shell: bash
       env:
         PLAN: ${{ env.TERRAFORM_PLAN }}
       with:


### PR DESCRIPTION
## About
In the current `tf-plan-comment` template, the Terraform plan from the initiating workflow is passed entirely as an argument. However, when the plan's size exceeds 256kb, as experienced with the Identity User Management API while planning the prod environment with the introduction of the Fargate environment, this method leads to workflow failures - `ERROR MESSAGE: argument is too long`. To address this, we're introducing a `v2` version of the `tf-plan-comment` template. In this version, the plan is transmitted as a file, which the template then processes. It's important to note that this change is a *breaking update*. Consumer pipelines must adapt by incorporating an additional step to save the plan as a file and then pass it using the `terraform_plan_file` argument, replacing the previous `terraform_plan` argument. To avoid disrupting existing pipelines, this new version will be released under the v2 tag. We strongly recommend migrating to this updated approach at the earliest convenience for enhanced reliability and efficiency.

## Dependencies of PR
https://github.com/OpenSesame/identity-user-management-api/pull/136

## Description of Changes
- [chore(tf-plan-comment): refactor terraform_plan_path to terraform_pla…](https://github.com/OpenSesame/core-github-actions/commit/8e8e1d75a5937e01060b7575091d045d4740ff42)

## Testing
Tested against the Identity User Management API workflow.

[Jira Task Link](https://opensesame.atlassian.net/browse/CORE-3303)