### PR TITLE
CORE 3852: added deploy and validate and plan workflows

### DIFF
--- a/.github/workflows/deploy_infra.yml
+++ b/.github/workflows/deploy_infra.yml
@@ -20,6 +20,10 @@ on:
         description: Terrafrom workspace that is used
         type: string
         required: true
+      terraform-root:
+        description: Root directory of terraform, default to 'terraform/${ inputs.environment }'
+        type: string
+        required: false
     secrets:
       ORG_READ_ONLY_SSH_KEY:
         required: true
@@ -36,7 +40,7 @@ permissions:
   contents: read
 
 env:
-  TERRAFORM_ROOT: ${{ inputs.environment }}
+  TERRAFORM_ROOT: terraform/${{ inputs.environment }}   
   TERRAFORM_WORKSPACE: ${{ inputs.terraform-workspace }}
   TF_INPUT: false
   TF_IN_AUTOMATION: true
@@ -46,6 +50,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       commit-tag: ${{ steps.get-commit-tag.outputs.commit-tag }}
+      TERRAFORM_ROOT: ${{ steps.set-env.outputs.TERRAFORM_ROOT }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.6
@@ -56,6 +61,16 @@ jobs:
         id: get-commit-tag
         run: |
           echo "commit-tag=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+
+      - name: Determine Terraform Root
+        id: set-env
+        run: |
+          if [ -n "${{ inputs.terraform-root }}" ]; then
+            echo "TERRAFORM_ROOT=${{ inputs.terraform-root }}" >> $GITHUB_ENV
+            echo "::set-output name=TERRAFORM_ROOT::${{ inputs.terraform-root }}"
+          else
+            echo "TERRAFORM_ROOT=terraform/${{ inputs.environment }}" >> $GITHUB_ENV
+            echo "::set-output name=TERRAFORM_ROOT::terraform/${{ inputs.environment }}"
 
       - name: Markdown Summary
         run: |
@@ -68,6 +83,7 @@ jobs:
           echo -e "${{ toJson(inputs) }}\n" >> $GITHUB_STEP_SUMMARY
           echo "**Release Tag**: ${{ inputs.release-tag }}" >> $GITHUB_STEP_SUMMARY
           echo "**Commit Tag**: ${{ steps.get-commit-tag.outputs.commit-tag }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Terraform Root**: ${{ env.TERRAFORM_ROOT }} " >> $GITHUB_STEP_SUMMARY
           echo "*Note: Workflow Ref & Sha represent the branch and commit of the workflow defintion. This may not be the same as the branch/commit checked out supplying the code. The 'SHA or tag of tests to run' aka commit-identifier, is what specifies the test defintions. If a commit-identifier is not supplied, the head of the selected branch is used.*" >> $GITHUB_STEP_SUMMARY
 
       - name: Validate Environment
@@ -81,9 +97,10 @@ jobs:
     name: Deploy Terraform
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment}}
+    needs: Setup
     defaults:
       run:
-        working-directory: terraform/${{ inputs.environment }}
+        working-directory: ${{ needs.Setup.outputs.TERRAFORM_ROOT }}
 
     steps:
       - id: get-role-arn

--- a/.github/workflows/deploy_infra.yml
+++ b/.github/workflows/deploy_infra.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       environment:
-        description: Environment to deploy (dev, stage, prod)
+        description: Github action environment 
         type: string
         required: true
       commit-identifier:
@@ -16,8 +16,8 @@ on:
         type: string
         required: false
         default: unnamed
-      workspace: 
-        description: workspace to use
+      terraform-workspace: 
+        description: Terrafrom workspace that is used
         type: string
         required: true
     secrets:
@@ -37,7 +37,7 @@ permissions:
 
 env:
   TERRAFORM_ROOT: ${{ inputs.environment }}
-  TERRAFORM_WORKSPACE: ${{ inputs.workspace }}
+  TERRAFORM_WORKSPACE: ${{ inputs.terraform-workspace }}
   TF_INPUT: false
   TF_IN_AUTOMATION: true
 
@@ -77,8 +77,8 @@ jobs:
             exit 1
           fi
 
-  Terraform-Apply:
-    name: Terraform Apply
+  Deploy-Terraform:
+    name: Deploy Terraform
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment}}
     defaults:
@@ -96,7 +96,7 @@ jobs:
       - uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ steps.get-role-arn.outputs.role-arn }}
-          role-session-name: ${{ inputs.workspace }}-${{ inputs.environment }}-Run${{ github.run_id }}
+          role-session-name: ${{ github.repository }}-${{ inputs.environment }}-Run${{ github.run_id }}
           aws-region: ${{ steps.get-role-arn.outputs.region }}
 
       - name: Checkout Actions
@@ -132,7 +132,7 @@ jobs:
   Notify-Slack:
     name:
     runs-on: ubuntu-latest
-    needs: [Terraform-Apply]
+    needs: [Deploy-Terraform]
     steps:
       - uses: ravsamhq/notify-slack-action@v2
         if: always()

--- a/.github/workflows/deploy_infra.yml
+++ b/.github/workflows/deploy_infra.yml
@@ -17,7 +17,7 @@ on:
         required: false
         default: unnamed
       terraform-workspace: 
-        description: Terrafrom workspace that is used
+        description: Terraform workspace that is used
         type: string
         required: true
       terraform-root:

--- a/.github/workflows/deploy_infra.yml
+++ b/.github/workflows/deploy_infra.yml
@@ -1,0 +1,146 @@
+name: Deploy to Infrastructure
+
+on:
+  workflow_call:
+    inputs:
+      environment:
+        description: Environment to deploy (dev, stage, prod)
+        type: string
+        required: true
+      commit-identifier:
+        description: SHA or tag to apply, (optional) when omitted, the head of the selected branch is used
+        type: string
+        required: true
+      release-tag:
+        description: release name to apply to resources
+        type: string
+        required: false
+        default: unnamed
+      workspace: 
+        description: workspace to use
+        type: string
+        required: true
+    secrets:
+      ORG_READ_ONLY_SSH_KEY:
+        required: true
+      ORG_GITHUB_PACKAGES_READ_ONLY_TOKEN:
+        required: true
+      CORE_ENG_DEPLOYMENTS_SLACK_WEBHOOK:
+        required: true
+
+concurrency:
+  group: ${{ github.workflow }}-${{ inputs.environment }}
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  TERRAFORM_ROOT: ${{ inputs.environment }}
+  TERRAFORM_WORKSPACE: ${{ inputs.workspace }}
+  TF_INPUT: false
+  TF_IN_AUTOMATION: true
+
+jobs:
+  Setup:
+    runs-on: ubuntu-latest
+    outputs:
+      commit-tag: ${{ steps.get-commit-tag.outputs.commit-tag }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.6
+        with:
+          ref: ${{ inputs.commit-identifier }}
+
+      - name: Get Build Commit Tag
+        id: get-commit-tag
+        run: |
+          echo "commit-tag=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+
+      - name: Markdown Summary
+        run: |
+          echo "### Deploy Infrastructure Context"  >> $GITHUB_STEP_SUMMARY
+          echo "**Trigger**: ${{ github.event_name }} ${{ github.event.action }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Actor**: ${{ github.actor }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Workflow Ref (branch)**: ${{ github.workflow_ref }}" >> $GITHUB_STEP_SUMMARY
+          echo -e "**Workflow Sha (commit)**: ${{ github.workflow_sha }}\n" >> $GITHUB_STEP_SUMMARY
+          echo "**Inputs**" >> $GITHUB_STEP_SUMMARY
+          echo -e "${{ toJson(inputs) }}\n" >> $GITHUB_STEP_SUMMARY
+          echo "**Release Tag**: ${{ inputs.release-tag }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Commit Tag**: ${{ steps.get-commit-tag.outputs.commit-tag }}" >> $GITHUB_STEP_SUMMARY
+          echo "*Note: Workflow Ref & Sha represent the branch and commit of the workflow defintion. This may not be the same as the branch/commit checked out supplying the code. The 'SHA or tag of tests to run' aka commit-identifier, is what specifies the test defintions. If a commit-identifier is not supplied, the head of the selected branch is used.*" >> $GITHUB_STEP_SUMMARY
+
+      - name: Validate Environment
+        run: |
+          if [[ ! "${{ inputs.environment }}" =~ ^(dev|stage|prod)$ ]]; then
+            echo "Invalid environment: ${{ inputs.environment }}"
+            exit 1
+          fi
+
+  Terraform-Apply:
+    name: Terraform Apply
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment}}
+    defaults:
+      run:
+        working-directory: terraform/${{ inputs.environment }}
+
+    steps:
+      - id: get-role-arn
+        uses: OpenSesame/gha-oidc-access/get-role-arn@v2
+        with:
+          domain: core
+          env: ${{ inputs.environment }}
+          ORG_READ_ONLY_SSH_KEY: ${{ secrets.ORG_READ_ONLY_SSH_KEY }}
+      
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ steps.get-role-arn.outputs.role-arn }}
+          role-session-name: ${{ inputs.workspace }}-${{ inputs.environment }}-Run${{ github.run_id }}
+          aws-region: ${{ steps.get-role-arn.outputs.region }}
+
+      - name: Checkout Actions
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.commit-identifier }}
+
+      - name: Configure Github Credentials
+        id: configure-credentials
+        shell: bash
+        run: |
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+          echo '${{ secrets.ORG_READ_ONLY_SSH_KEY }}' > ~/.ssh/id_rsa
+          ssh-keyscan github.com > ~/.ssh/known_hosts
+          chmod 600 ~/.ssh/id_rsa ~/.ssh/known_hosts
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.8.4
+          terraform_wrapper: false # required to access terraform outputs after apply
+
+      - name: Init Terraform
+        run: terraform init -upgrade
+
+      - name: Select Workspace
+        run: terraform workspace select -or-create ${{ env.TERRAFORM_WORKSPACE }}
+
+      - name: Apply Terraform
+        run: terraform apply -auto-approve -input=false
+
+  Notify-Slack:
+    name:
+    runs-on: ubuntu-latest
+    needs: [Terraform-Apply]
+    steps:
+      - uses: ravsamhq/notify-slack-action@v2
+        if: always()
+        with:
+          status: ${{ job.status }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          notification_title: "<{repo_url}|{repo}> {workflow}"
+          message_format: "Release ${{ inputs.release-tag }}\ndeployed commit ${{ inputs.commit-identifier }}\n{emoji} ${{ inputs.environment }} {status_message}"
+          footer: "Workflow: {run_url}|View"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.CORE_ENG_DEPLOYMENTS_SLACK_WEBHOOK }}

--- a/.github/workflows/deploy_infra.yml
+++ b/.github/workflows/deploy_infra.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       environment:
-        description: Github action environment 
+        description: Github action environment and AWS account type
         type: string
         required: true
       commit-identifier:

--- a/.github/workflows/validate_plan_tf.yml
+++ b/.github/workflows/validate_plan_tf.yml
@@ -21,7 +21,7 @@ on:
         required: false
         default: false
       terraform-workspace: 
-        description: Terrafrom workspace that is used
+        description: Terraform workspace that is used
         type: string
         required: true
     secrets:

--- a/.github/workflows/validate_plan_tf.yml
+++ b/.github/workflows/validate_plan_tf.yml
@@ -1,0 +1,152 @@
+name: TF Validate and Plan
+
+on:
+  workflow_call:
+    inputs:
+      environment:
+        description: Environment to terraform validate and plan (dev, stage, prod)
+        type: string
+        required: true
+      commit-identifier:
+        description: "SHA or tag to validate and plan terraform, (optional) when omitted, the head of the selected branch is used"
+        type: string
+        required: true 
+      with-lock:
+        description: whether to lock the state file or not, (default - true)
+        type: boolean
+        default: true
+      write-artifact:
+        description: write the terraform plan to an artifact
+        type: boolean
+        required: false
+        default: false
+      workspace: 
+        description: workspace to use
+        type: string
+        required: true
+    secrets:
+      ORG_READ_ONLY_SSH_KEY:
+        required: true
+      ORG_GITHUB_PACKAGES_READ_ONLY_TOKEN:
+        required: true
+    outputs:
+      plan-artifact-name:
+        description: the name of the plan artifact, if write-artifact is true
+        value: ${{ jobs.TF-Validate-Plan.outputs.plan-artifact-name}}
+
+concurrency: 
+  group: ${{ github.workflow }}-${{ inputs.environment }}
+
+permissions:
+  id-token: write  # required by configure-aws-credentials
+  contents: read
+
+env:
+  TERRAFORM_ROOT: ${{ inputs.environment }}
+  TERRAFORM_WORKSPACE: ${{ inputs.environment }}
+
+jobs: 
+  TF-Validate-Plan:
+    name: Terraform Validate and Plan
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    defaults: # runs all steps in this directory
+      run:
+        working-directory: ./terraform/${{ inputs.environment }}
+    outputs:
+      plan-artifact-name: ${{ steps.set-plan-artifact-name.outputs.artifact_name }}
+    
+    steps:
+      - name: Validate Environment
+        working-directory: /
+        # checks environment with regex
+        run: |
+          if [[ ! "${{ inputs.environment }}" =~ ^(dev|stage|prod)$ ]]; then
+            echo "Error: Invalid environment '${{ inputs.environment }}'. Environment values are 'dev', 'stage' or 'prod'."
+            exit 1
+          fi 
+
+      - id: get-role-arn
+        uses: OpenSesame/gha-oidc-access/get-role-arn@v2
+        with:
+          domain: core
+          env: ${{ inputs.environment }}
+          ORG_READ_ONLY_SSH_KEY: ${{ secrets.ORG_READ_ONLY_SSH_KEY }}
+      
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ steps.get-role-arn.outputs.role-arn }}
+          role-session-name: ${{ inputs.workspace }}-${{ inputs.environment }}-Run${{ github.run_id }}
+          aws-region: ${{ steps.get-role-arn.outputs.region }}
+
+      - name: Checkout Actions
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.commit-identifier }}
+
+      - name: Configure Github Credentials
+        id: configure-credentials
+        shell: bash
+        run: |
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+          echo '${{ secrets.ORG_READ_ONLY_SSH_KEY }}' > ~/.ssh/id_rsa
+          ssh-keyscan github.com > ~/.ssh/known_hosts
+          chmod 600 ~/.ssh/id_rsa ~/.ssh/known_hosts
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.8.4
+          terraform_wrapper: false # required to access terraform outputs after apply
+
+      - name: Terraform Init
+        run: terraform init -upgrade
+
+      - name: Terraform Validate
+        run: terraform validate
+
+      - name: Select or create terraform workplace
+        run: terraform workspace select -or-create ${{ env.TERRAFORM_WORKSPACE }}
+
+      - name: Terrafrom Re-Init
+        run: terraform init -upgrade
+
+      - name: Terraform Plan
+        id: plan
+        run: |
+          export TF_VAR_github_personal_access_token="${{ secrets.ORG_GITHUB_PACKAGES_READ_WRITE_TOKEN }}"
+          terraform plan -lock=${{ inputs.with-lock }} -out=tfplan
+      
+      - name: Write Plans to Run Comment
+        id: write-plans
+        run: |
+          if [ -f tfplan ]; then
+            echo "#### $(basename "$(pwd)") plan" >> $GITHUB_STEP_SUMMARY
+            terraform show tfplan -no-color > tfplan.txt
+            echo "<details>" >> $GITHUB_STEP_SUMMARY
+            echo "<summary>Click to show plan</summary>" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "~~~ terraform" >> $GITHUB_STEP_SUMMARY
+            cat tfplan.txt >> $GITHUB_STEP_SUMMARY
+            echo "~~~" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "</details>" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "Warning: No plan file found in $(pwd)" >> $GITHUB_STEP_SUMMARY
+            echo "skipping writing plans to run comment" >> $GITHUB_STEP_SUMMARY
+          fi
+      
+      - name: Set Plan Artifact Name
+        id: set-plan-artifact-name
+        if: ${{ inputs.write-artifact }}
+        run: echo "artifact_name=${{ inputs.environment }}-tfplan-${{ github.run_id }}" >> $GITHUB_OUTPUT
+
+      - name: Upload Plans to Artifact
+        id: plan-artifact
+        if: ${{ inputs.write-artifact }}
+        uses: actions/upload-artifact@v4.3.3
+        with:
+          name: ${{steps.set-plan-artifact-name.outputs.artifact_name}}
+          path: terraform/${{ inputs.environment }}/tfplan.txt
+  

--- a/.github/workflows/validate_plan_tf.yml
+++ b/.github/workflows/validate_plan_tf.yml
@@ -24,6 +24,10 @@ on:
         description: Terraform workspace that is used
         type: string
         required: true
+      terraform-root:
+        description: Root directory of terraform, default to 'terraform/${ inputs.environment }'
+        type: string
+        required: false
     secrets:
       ORG_READ_ONLY_SSH_KEY:
         required: true
@@ -42,16 +46,36 @@ permissions:
   contents: read
 
 env:
+  TERRAFORM_ROOT: terraform/${{ inputs.environment }}   
   TERRAFORM_WORKSPACE: ${{ inputs.terraform-workspace }}
 
 jobs: 
+  Setup:
+    runs-on: ubuntu-latest
+    outputs:
+      TERRAFORM_ROOT: ${{ steps.set-env.outputs.TERRAFORM_ROOT }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.6
+        with:
+          ref: ${{ inputs.commit-identifier }}
+    
+      - name: Determine Terraform Root
+        id: set-env
+        run: |
+          if [ -n "${{ inputs.terraform-root }}" ]; then
+            echo "::set-output name=TERRAFORM_ROOT::${{ inputs.terraform-root }}"
+          else
+            echo "::set-output name=TERRAFORM_ROOT::terraform/${{ inputs.environment }}"
+
   TF-Validate-Plan:
     name: Plan-Terraform
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
+    needs: Setup
     defaults: # runs all steps in this directory
       run:
-        working-directory: ./terraform/${{ inputs.environment }}
+        working-directory: ${{ needs.Setup.outputs.TERRAFORM_ROOT }}
     outputs:
       plan-artifact-name: ${{ steps.set-plan-artifact-name.outputs.artifact_name }}
     

--- a/.github/workflows/validate_plan_tf.yml
+++ b/.github/workflows/validate_plan_tf.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       environment:
-        description: Github action environment
+        description: Github action environment and AWS account type
         type: string
         required: true
       commit-identifier:

--- a/.github/workflows/validate_plan_tf.yml
+++ b/.github/workflows/validate_plan_tf.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       environment:
-        description: Environment to terraform validate and plan (dev, stage, prod)
+        description: Github action environment
         type: string
         required: true
       commit-identifier:
@@ -20,8 +20,8 @@ on:
         type: boolean
         required: false
         default: false
-      workspace: 
-        description: workspace to use
+      terraform-workspace: 
+        description: Terrafrom workspace that is used
         type: string
         required: true
     secrets:
@@ -42,12 +42,11 @@ permissions:
   contents: read
 
 env:
-  TERRAFORM_ROOT: ${{ inputs.environment }}
-  TERRAFORM_WORKSPACE: ${{ inputs.environment }}
+  TERRAFORM_WORKSPACE: ${{ inputs.terraform-workspace }}
 
 jobs: 
   TF-Validate-Plan:
-    name: Terraform Validate and Plan
+    name: Plan-Terraform
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
     defaults: # runs all steps in this directory
@@ -76,7 +75,7 @@ jobs:
       - uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ steps.get-role-arn.outputs.role-arn }}
-          role-session-name: ${{ inputs.workspace }}-${{ inputs.environment }}-Run${{ github.run_id }}
+          role-session-name: ${{ inputs.terraform-workspace }}-${{ inputs.environment }}-Run${{ github.run_id }}
           aws-region: ${{ steps.get-role-arn.outputs.region }}
 
       - name: Checkout Actions
@@ -106,7 +105,7 @@ jobs:
       - name: Terraform Validate
         run: terraform validate
 
-      - name: Select or create terraform workplace
+      - name: Select Workplace
         run: terraform workspace select -or-create ${{ env.TERRAFORM_WORKSPACE }}
 
       - name: Terrafrom Re-Init


### PR DESCRIPTION
## Description of Changes

Added reusable deploy_infra and validate_plan_tf files which will be called in standard workflows for other repos

## Testing
Testing will need to be done when they are called in other repos

[Jira Task Link](https://opensesame.atlassian.net/browse/core-3852)
