### PR TITLE
Set

### DIFF
--- a/.github/workflows/tf_validate_plan_env_roots.yml
+++ b/.github/workflows/tf_validate_plan_env_roots.yml
@@ -15,6 +15,10 @@ on:
         description: Terraform version to use
         type: string
         required: true
+      build-artifact-directory:
+        description: Optional directory to create before running terraform plan. Path should be relative to the terraform envirionment root directories
+        type: string
+        required: false
     secrets:
       ORG_READ_ONLY_SSH_KEY:
         required: true
@@ -24,7 +28,7 @@ on:
 jobs:
   TF-Validate-Plan-Roots:
     name: TF Validate/Plan ENV Roots
-    uses: ./.github/workflows/tf_validate_plan_single_root.yml
+    uses: opensesame/core-github-actions/.github/workflows/tf_validate_plan_single_root.yml@beta
     strategy:
       fail-fast: false # continues to run jobs even if one fails
       matrix:
@@ -42,6 +46,7 @@ jobs:
       terraform-workspace: ${{ inputs.terraform-workspace || matrix.environment }}
       terraform-root: terraform/${{ matrix.environment }}
       terraform-version: ${{ inputs.terraform-version }}
+      build-artifact-directory: ${{ inputs.build-artifact-directory }}
     secrets:
       ORG_READ_ONLY_SSH_KEY: ${{ secrets.ORG_READ_ONLY_SSH_KEY }}
       ORG_GITHUB_PACKAGES_READ_ONLY_TOKEN: ${{ secrets.ORG_GITHUB_PACKAGES_READ_ONLY_TOKEN }}

--- a/.github/workflows/tf_validate_plan_single_root.yml
+++ b/.github/workflows/tf_validate_plan_single_root.yml
@@ -31,6 +31,10 @@ on:
         description: Terraform version to use
         type: string
         required: true
+      build-artifact-directory:
+        description: Optional directory to create before running terraform plan. Path should be relative to the terraform-root supplied
+        type: string
+        required: false
     secrets:
       ORG_READ_ONLY_SSH_KEY:
         required: true
@@ -98,6 +102,11 @@ jobs:
           terraform_version: ${{ inputs.terraform-version }}
           terraform_wrapper: false # required to access terraform outputs after apply
 
+      # Step to create the directory if the build-artifact-directory input is provided
+      - name: Ensure Build Artifact Directory Exists
+        if: ${{ inputs.build-artifact-directory != '' }}
+        run: mkdir -p ${{ inputs.build-artifact-directory }}
+
       - name: Terraform Init
         run: terraform init -upgrade
 
@@ -107,7 +116,7 @@ jobs:
       - name: Select Workplace
         run: terraform workspace select -or-create ${{ inputs.terraform-workspace }}
 
-      - name: Terrafrom Re-Init
+      - name: Terraform Re-Init
         run: terraform init -upgrade
 
       - name: Terraform Plan

--- a/select-branch-workspace/README.md
+++ b/select-branch-workspace/README.md
@@ -1,0 +1,5 @@
+# Overview
+
+Takes in a string input meant to be the name of a branch.
+The branch name is sanitized to be used as a workspace name.
+The resulting workspace name is then used to select the workspace, creating it if it does not exist.

--- a/select-branch-workspace/action.yml
+++ b/select-branch-workspace/action.yml
@@ -1,0 +1,26 @@
+name: Sanitize Branch Name for Terraform Workspace
+description: Removes everything before the final "/" from the branch name and limits the characters.
+inputs:
+  branch_name:
+    description: The name of the branch to be sanitized
+    required: true
+outputs:
+  workspace_name:
+    description: "Branch name after the final forward slash"
+    value: ${{ steps.sanitize_branch.outputs.sanitized_branch_name }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Sanitize input branch
+      id: sanitize_branch
+      shell: bash
+      run: |
+        SANITIZED_BRANCH_NAME=$(echo ${{ github.ref_name }} | sed 's/.*\///' | sed 's/\(^.\{1,50\}\).*/\1/')
+        echo "Sanitized branch name: $SANITIZED_BRANCH_NAME"
+        terraform workspace select -or-create $SANITIZED_BRANCH_NAME
+        echo "sanitized_branch_name=$SANITIZED_BRANCH_NAME" >> $GITHUB_OUTPUT
+
+    # sed 's/.*\///' removes everything before the final slash
+    # sed 's/\(^.\{1,50\}\).*/\1/' #Character limit is 50. Terraform workspace allows up to 90 characters
+    # TODO: Remove special characters. Eg sed 's/[#$%*@]//g'

--- a/select-branch-workspace/action.yml
+++ b/select-branch-workspace/action.yml
@@ -16,7 +16,7 @@ runs:
       id: sanitize_branch
       shell: bash
       run: |
-        SANITIZED_BRANCH_NAME=$(echo ${{ github.ref_name }} | sed 's/.*\///' | sed 's/\(^.\{1,50\}\).*/\1/')
+        SANITIZED_BRANCH_NAME=$(echo ${{ inputs.branch_name }} | sed 's/.*\///' | sed 's/\(^.\{1,50\}\).*/\1/')
         echo "Sanitized branch name: $SANITIZED_BRANCH_NAME"
         terraform workspace select -or-create $SANITIZED_BRANCH_NAME
         echo "sanitized_branch_name=$SANITIZED_BRANCH_NAME" >> $GITHUB_OUTPUT

--- a/select-branch-workspace/action.yml
+++ b/select-branch-workspace/action.yml
@@ -16,6 +16,8 @@ runs:
       id: sanitize_branch
       shell: bash
       run: |
+        pwd
+        terraform workspace list
         SANITIZED_BRANCH_NAME=$(echo ${{ inputs.branch_name }} | sed 's/.*\///' | sed 's/\(^.\{1,50\}\).*/\1/')
         echo "Sanitized branch name: $SANITIZED_BRANCH_NAME"
         terraform workspace select -or-create $SANITIZED_BRANCH_NAME

--- a/select-branch-workspace/action.yml
+++ b/select-branch-workspace/action.yml
@@ -1,11 +1,14 @@
 name: Sanitize Branch Name for Terraform Workspace
 description: Removes everything before the final "/" from the branch name and limits the characters.
 inputs:
-  branch_name:
+  branch-name:
     description: The name of the branch to be sanitized
     required: true
+  working-directory:
+    description: the directory the step should be run from
+    required: true
 outputs:
-  workspace_name:
+  workspace-name:
     description: "Branch name after the final forward slash"
     value: ${{ steps.sanitize_branch.outputs.sanitized_branch_name }}
 
@@ -17,8 +20,10 @@ runs:
       shell: bash
       run: |
         pwd
+        cd ${{ inputs.working-directory }}
+        pwd
         terraform workspace list
-        SANITIZED_BRANCH_NAME=$(echo ${{ inputs.branch_name }} | sed 's/.*\///' | sed 's/\(^.\{1,50\}\).*/\1/')
+        SANITIZED_BRANCH_NAME=$(echo ${{ inputs.branch-name }} | sed 's/.*\///' | sed 's/\(^.\{1,50\}\).*/\1/')
         echo "Sanitized branch name: $SANITIZED_BRANCH_NAME"
         terraform workspace select -or-create $SANITIZED_BRANCH_NAME
         echo "sanitized_branch_name=$SANITIZED_BRANCH_NAME" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Dependencies of PR
N/A

## Description of Changes

- added optional input of `build-artifact-directory` into terraform plan GHAs so an empty dir can be deleted at that path before plan. This prefevents the need for a build in order to plan
- added composite action to select workspace based on input. Use case would be to pass in a branch name and sanitize it as a workspace name

## Testing

- Select Branch Workspace
-- https://github.com/OpenSesame/okta-token-mgmt-api/actions/runs/11042309496
-- https://github.com/OpenSesame/okta-token-mgmt-api/actions/runs/11042313798

- Validate/Plan TF ENV roots
-- (failures of stage & prod expected in this repo and unrelated to change) https://github.com/OpenSesame/okta-token-mgmt-api/actions/runs/11041762597

[Jira Task Link](https://opensesame.atlassian.net/browse/CORE-3999)
